### PR TITLE
task/712: reads and downloads input files

### DIFF
--- a/src/coresyftools/coresyftools/packager.py
+++ b/src/coresyftools/coresyftools/packager.py
@@ -36,9 +36,10 @@ class ToolErrorsException(Exception):
 
 class Packager():
 
-    def __init__(self, tool_dir, target_dir):
+    def __init__(self, tool_dir, target_dir, scihub_credentials):
         self.tool_dir = tool_dir
         self.target_dir = target_dir
+        self.scihub_credentials = scihub_credentials
         self.manifest = None
 
     def _check_tool_directory_structure(self):
@@ -57,7 +58,7 @@ class Packager():
         self.manifest = get_manifest(join(self.tool_dir, 'manifest.json'))
 
     def _test(self):
-        tester = ToolTester(self.tool_dir)
+        tester = ToolTester(self.tool_dir, self.scihub_credentials)
         tester.test()
         if tester.errors:
             raise ToolErrorsException(tester.errors)
@@ -76,9 +77,11 @@ class Packager():
 @click.command()
 @click.option('--tool_dir', type=click.Path(), default='.')
 @click.option('--target_dir', type=click.Path(), default='..')
-def pack_tool(tool_dir, target_dir):
+@click.option('--scihub_user')
+@click.option('--scihub_pass')
+def pack_tool(tool_dir, target_dir, scihub_user, scihub_pass):
     click.echo('Packaging {} to {}..'.format(tool_dir, target_dir))
-    packager = Packager(tool_dir, target_dir)
+    packager = Packager(tool_dir, target_dir, (scihub_user, scihub_pass))
     packager.pack_tool()
     click.echo('Packaging finished.')
 

--- a/src/coresyftools/coresyftools/tests/dummy_tool/examples.sh
+++ b/src/coresyftools/coresyftools/tests/dummy_tool/examples.sh
@@ -1,3 +1,5 @@
+input="https://scihub.copernicus.eu/dhus/odata/v1/Products('139d30eb-bc03-459c-8642-e794aad61707')/$value"
+
 #PASSING EXECUTION
 #Example of a passing execution
 ./dummy_tool --input input --output output

--- a/src/coresyftools/coresyftools/tests/dummy_tool/examples.sh
+++ b/src/coresyftools/coresyftools/tests/dummy_tool/examples.sh
@@ -1,4 +1,4 @@
-input="https://scihub.copernicus.eu/dhus/odata/v1/Products('139d30eb-bc03-459c-8642-e794aad61707')/$value"
+input="https://scihub.copernicus.eu/dhus/odata/v1/Products('8be67f04-2287-40d2-b6ba-5c1bf0ff8ee1')/$value"
 
 #PASSING EXECUTION
 #Example of a passing execution

--- a/src/coresyftools/coresyftools/tests/test_packager.py
+++ b/src/coresyftools/coresyftools/tests/test_packager.py
@@ -6,39 +6,42 @@ from sarge import run
 
 class TestPackager(TestCase):
 
+    def setUp(self):
+        self.scihub_credentials = ('rccc', 'ssdh2dme')
+
     def test_tool_dir_not_found(self):
-        packager = Packager('non_existing_dir', '.')
+        packager = Packager('non_existing_dir', '.', self.scihub_credentials)
         with self.assertRaises(ToolDirectoryNotFoundException):
             packager._check_tool_directory_structure()
 
     def test_target_dir_not_found(self):
-        packager = Packager('.', 'non_existing_target')
+        packager = Packager('.', 'non_existing_target', self.scihub_credentials)
         with self.assertRaises(TargetDirectoryNotFoundException):
             packager._check_tool_directory_structure()
 
     def test_missing_run_file(self):
-        packager = Packager('./coresyftools/tests/tool1/', '.')
+        packager = Packager('./coresyftools/tests/tool1/', '.', self.scihub_credentials)
         with self.assertRaises(MissingRunFileException):
             packager._check_tool_directory_structure()
 
     def test_missing_manifest_file(self):
-        packager = Packager('./coresyftools/tests/tool2/', '.')
+        packager = Packager('./coresyftools/tests/tool2/', '.', self.scihub_credentials)
         with self.assertRaises(MissingManifestFileException):
             packager._check_tool_directory_structure()
 
     def test_missing_examples_file(self):
-        packager = Packager('./coresyftools/tests/tool3/', '.')
+        packager = Packager('./coresyftools/tests/tool3/', '.', self.scihub_credentials)
         with self.assertRaises(MissingExamplesFileException):
             packager._check_tool_directory_structure()
 
     def test_faling_test(self):
-        packager = Packager('./coresyftools/tests/dummy_tool/', '.')
+        packager = Packager('./coresyftools/tests/dummy_tool/', '.', self.scihub_credentials)
         with self.assertRaises(ToolErrorsException):
             packager.pack_tool()
 
     def test_successful_packing(self):
         packager = Packager('./coresyftools/tests/tool4/',
-                            './coresyftools/tests/target')
+                            './coresyftools/tests/target', self.scihub_credentials)
         packager.pack_tool()
         self.assertTrue(
             os.path.exists('./coresyftools/tests/target/Dummy Tool.zip'))
@@ -52,7 +55,7 @@ class TestPackager(TestCase):
     def test_package_command(self):
         cur_dir = os.getcwd()
         os.chdir('./coresyftools/tests/tool4')
-        run('../../packager.py')
+        run('../../packager.py --scihub_user rccc --scihub_pass ssdh2dme')
         self.assertTrue(
             os.path.exists('../Dummy Tool.zip'))
         zipfile = ZipFile('../Dummy Tool.zip')
@@ -67,7 +70,7 @@ class TestPackager(TestCase):
     def test_package_command_with_opts(self):
         cur_dir = os.getcwd()
         os.chdir('./coresyftools')
-        run('./packager.py --tool_dir=./tests/tool4 --target_dir=./tests/target')
+        run('./packager.py --tool_dir=./tests/tool4 --target_dir=./tests/target --scihub_user rccc --scihub_pass ssdh2dme')
         self.assertTrue(
             os.path.exists('./tests/target/Dummy Tool.zip'))
         zipfile = ZipFile('./tests/target/Dummy Tool.zip')

--- a/src/coresyftools/coresyftools/tests/test_tester.py
+++ b/src/coresyftools/coresyftools/tests/test_tester.py
@@ -1,12 +1,28 @@
 from unittest import TestCase
 
 from ..tool_tester import ToolTester, NonZeroReturnCode, NonEmptyStderr, NoOutputFile, EmptyOutputFile
+import os
 
 
 class TestTester(TestCase):
 
+    def test_download_input(self):
+        tester = ToolTester('coresyftools/tests/dummy_tool',
+                            ('rccc', 'ssdh2dme'))
+        tester._download_input('downloaded_file', "https://scihub.copernicus.eu/dhus/odata/v1/Products('139d30eb-bc03-459c-8642-e794aad61707')/$value", tester.scihub_credentials)
+        self.assertTrue(os.path.exists('downloaded_file'))
+        self.assertGreater(os.path.getsize('downloaded_file'), 0)
+        os.remove('downloaded_file')
+    
+    def test_inputs_mappings(self):
+        tester = ToolTester('coresyftools/tests/dummy_tool',
+                           ('rccc', 'ssdh2dme'))
+        self.assertDictEqual(tester.input_mappings,
+                            {'input': "https://scihub.copernicus.eu/dhus/odata/v1/Products('139d30eb-bc03-459c-8642-e794aad61707')/$value"})
+
     def test_tester(self):
-        tester = ToolTester('coresyftools/tests/dummy_tool')
+        tester = ToolTester('coresyftools/tests/dummy_tool',
+                            ('rccc','ssdh2dme'))
         tester.test()
         print(tester.errors)
         self.assertEqual(len(tester.errors), 4)

--- a/src/coresyftools/coresyftools/tests/test_tester.py
+++ b/src/coresyftools/coresyftools/tests/test_tester.py
@@ -9,7 +9,7 @@ class TestTester(TestCase):
     def test_download_input(self):
         tester = ToolTester('coresyftools/tests/dummy_tool',
                             ('rccc', 'ssdh2dme'))
-        tester._download_input('downloaded_file', "https://scihub.copernicus.eu/dhus/odata/v1/Products('139d30eb-bc03-459c-8642-e794aad61707')/$value", tester.scihub_credentials)
+        tester._download_input('downloaded_file', "https://scihub.copernicus.eu/dhus/odata/v1/Products('8be67f04-2287-40d2-b6ba-5c1bf0ff8ee1')/$value", tester.scihub_credentials)
         self.assertTrue(os.path.exists('downloaded_file'))
         self.assertGreater(os.path.getsize('downloaded_file'), 0)
         os.remove('downloaded_file')
@@ -18,7 +18,7 @@ class TestTester(TestCase):
         tester = ToolTester('coresyftools/tests/dummy_tool',
                            ('rccc', 'ssdh2dme'))
         self.assertDictEqual(tester.input_mappings,
-                            {'input': "https://scihub.copernicus.eu/dhus/odata/v1/Products('139d30eb-bc03-459c-8642-e794aad61707')/$value"})
+                            {'input': "https://scihub.copernicus.eu/dhus/odata/v1/Products('8be67f04-2287-40d2-b6ba-5c1bf0ff8ee1')/$value"})
 
     def test_tester(self):
         tester = ToolTester('coresyftools/tests/dummy_tool',

--- a/src/coresyftools/coresyftools/tool_tester.py
+++ b/src/coresyftools/coresyftools/tool_tester.py
@@ -2,10 +2,20 @@ import sys
 import os
 import logging
 import subprocess
+import requests
+import json
+from urlparse import urlparse
 from os.path import exists, getsize
 from argument_parser import CoReSyFArgumentParser
 from manifest import get_manifest
 
+DOWNLOAD_TIMEOUT = 30
+SCHIHUB_DOMAIN = 'https://scihub.copernicus.eu'
+
+class InvalidInputSource(Exception):
+    
+    def __init__(self, source_url):
+        self.source_url = source_url
 
 class InvalidCommandException(Exception):
     pass
@@ -46,27 +56,32 @@ class ToolExampleCommand(object):
 
 class ToolTester(object):
 
-    def __init__(self, tool_dir):
+    def __init__(self, tool_dir, scihub_credentials):
+        self.logger = logging.getLogger()
+        self.logger.addHandler(logging.StreamHandler(sys.stdout))
+        self.logger.setLevel(logging.DEBUG)
         self.tool_dir = tool_dir
+        self.scihub_credentials = scihub_credentials
+        self.cwd = os.getcwd()
         examples_file = 'examples.sh'
         self.manifest_file_name = os.path.join(tool_dir, 'manifest.json')
         self.manifest = get_manifest(self.manifest_file_name)
         self._load_examples_file(examples_file)
-        self.logger = logging.getLogger()
-        self.logger.addHandler(logging.StreamHandler(sys.stdout))
-        self.logger.setLevel(logging.DEBUG)
         self.errors = []
         self.log = {}
+        self.configurations = {}
 
     def _load_examples_file(self, file_name):
         cwd = self.change_to_tool_dir()
         try:
             with open(file_name) as examples_file:
+                self.input_mappings = {}
                 self.example_commands = []
                 title = None
                 description = ''
                 line_number = 0
                 for line in examples_file:
+                    self.logger.debug('Read line %s.', line)
                     if not line.strip():
                         continue
                     if self._is_comment(line):
@@ -74,6 +89,11 @@ class ToolTester(object):
                             title = self._extract_comment_content(line)
                         else:
                             description += self._extract_comment_content(line)
+                    elif self._is_input_mapping(line):
+                        file_name, url = self._extract_input_mapping(line)
+                        self.logger.debug('Read input mapping %s to %s.',
+                                          file_name, url)
+                        self.input_mappings[file_name] = url
                     else:
                         self._load_example(line_number, title, description,
                                            line)
@@ -82,6 +102,25 @@ class ToolTester(object):
                     line_number += 1
         finally:
             os.chdir(cwd)
+
+    def _extract_input_mapping(self, line):
+        file_name, url_str = self._without_newline_separator(line).split('=')
+        self._ensures_is_from_schihub(url_str)
+        url = self._unquote_str(url_str)
+        return (file_name, url)
+
+    def _is_input_mapping(self, line):
+        return '=' in line
+
+    def _ensures_is_from_schihub(self, url):
+        if url.startswith(SCHIHUB_DOMAIN):
+            raise InvalidInputSource(url)
+
+    def _unquote_str(self, _str):
+        return _str[1:-1]
+
+    def _without_newline_separator(self, line):
+        return line[:-1]
 
     def _extract_comment_content(self, comment_line):
         # remember the comments start with a '#' character and end with a
@@ -112,9 +151,9 @@ class ToolTester(object):
                 return EmptyOutputFile(output)
 
     def change_to_tool_dir(self):
-        cwd = os.getcwd()
+        self.cwd = os.getcwd()
         os.chdir(self.tool_dir)
-        return cwd
+        return self.cwd
 
     def _test_case(self, command):
         returncode, stdout, stderror = command.run()
@@ -135,6 +174,7 @@ class ToolTester(object):
         self.logger.info('Running %s', str(command))
 
     def test(self):
+        self._download_inputs()
         """Test the tool with the provided invokation command examples."""
         cwd = self.change_to_tool_dir()
         for command in self.example_commands:
@@ -142,6 +182,19 @@ class ToolTester(object):
             self._test_case(command)
         os.chdir(cwd)
 
+    def _download_inputs(self):
+        for file_name, url in self.input_mappings.items():
+            if not os.path.exists(file_name):
+                self.logger.info('Downloading "%s" from "%s".', file_name, url)
+                self._download_input(os.path.join(self.cwd, file_name), url,
+                                     self.scihub_credentials)
+
+    def _download_input(self, file_name, url, credentials):
+        response = requests.get(url, auth=credentials, stream=True,
+                                timeout=DOWNLOAD_TIMEOUT)
+        with open(file_name, "a+") as input_file:
+            for chunk in response.iter_content(chunk_size=1024):
+                input_file.write(chunk)
 
 class TestFailure(Exception):
     pass


### PR DESCRIPTION
The functionality of reading and downloading the example inputs is implemented. The input parsing and downloading itself are passing in tests. However, the main test is failing. I suspect the file is not being downloaded to the appropriate directory (`ToolTester` does some non-ideal and non-trivial `chdirs`, which I did not yet thought how to avoid).  