### PR TITLE
Task/773 manifest parameter

### DIFF
--- a/src/coresyftools/coresyftools/gpt_tool.py
+++ b/src/coresyftools/coresyftools/gpt_tool.py
@@ -61,8 +61,7 @@ class GPTCoReSyFTool(CoReSyFTool):
         bindings = bindings.copy()
         operator = self.operation.get('operation')
         if 'graph' in self.operation and self.operation['graph']:
-            graph_file_name = self._graph_file_path(self.operation)
-            graph_file = os.path.join(self.context_directory, graph_file_name)
+            graph_file = self._graph_file_path(self.operation)
             if not os.path.exists(graph_file):
                 raise GPTGraphFileNotFound(graph_file)
             operator = graph_file

--- a/src/coresyftools/coresyftools/gpt_tool.py
+++ b/src/coresyftools/coresyftools/gpt_tool.py
@@ -34,6 +34,12 @@ class GPTCoReSyFTool(CoReSyFTool):
     DEFAULT_EXT = 'tif'
     DEFAULT_GPT_GRAPH_FILE_NAME = 'gpt_graph.xml'
 
+    def _graph_file_path(self, operation_dict):
+        graph_file_name = self.DEFAULT_GPT_GRAPH_FILE_NAME
+        if isinstance(operation_dict['graph'], basestring):
+            graph_file_name = operation_dict['graph']
+        return os.path.join(self.context_directory, graph_file_name)
+
     # this overrides the super-class method extending it's validation behaviour
     # the method is invoked during super-class __init__
     def _validate_operation(self, operation):
@@ -42,7 +48,7 @@ class GPTCoReSyFTool(CoReSyFTool):
         if 'operation' in operation and 'graph' in operation and operation['graph']:
             raise InvalidManifestException('Cannot be operation and graph at same time.')
         if self.operation.get('graph') is not None:
-            graph_file = os.path.join(self.context_directory, self.DEFAULT_GPT_GRAPH_FILE_NAME)
+            graph_file = self._graph_file_path(operation)
             if not os.path.exists(graph_file):
                 raise GPTGraphFileNotFound(graph_file)
 
@@ -55,7 +61,8 @@ class GPTCoReSyFTool(CoReSyFTool):
         bindings = bindings.copy()
         operator = self.operation.get('operation')
         if 'graph' in self.operation and self.operation['graph']:
-            graph_file = os.path.join(self.context_directory, self.DEFAULT_GPT_GRAPH_FILE_NAME)
+            graph_file_name = self._graph_file_path(self.operation)
+            graph_file = os.path.join(self.context_directory, graph_file_name)
             if not os.path.exists(graph_file):
                 raise GPTGraphFileNotFound(graph_file)
             operator = graph_file

--- a/src/coresyftools/coresyftools/tests/test_gpt_tool.py
+++ b/src/coresyftools/coresyftools/tests/test_gpt_tool.py
@@ -76,10 +76,9 @@ class TestGPTTool(TestCase):
 
     def test_graph(self):
         manifest = self.manifest.copy()
-        graph_file_name = 'gpt_graph.xml'
+        graph_file_name = 'my_tool.gpt_graph.xml'
         manifest['operation'] = {
-            'graph': True,
-            'file_name': graph_file_name
+            'graph': graph_file_name
         }
         self.write_manifest(manifest)
 

--- a/src/coresyftools/coresyftools/tests/test_gpt_tool.py
+++ b/src/coresyftools/coresyftools/tests/test_gpt_tool.py
@@ -76,10 +76,14 @@ class TestGPTTool(TestCase):
 
     def test_graph(self):
         manifest = self.manifest.copy()
-        manifest['operation'] = {'graph': True}
+        graph_file_name = 'gpt_graph.xml'
+        manifest['operation'] = {
+            'graph': True,
+            'file_name': graph_file_name
+        }
         self.write_manifest(manifest)
 
-        with open('gpt_graph.xml', 'w'):
+        with open(graph_file_name, 'w'):
             pass
 
         tool = GPTCoReSyFTool(self.runfile)
@@ -99,11 +103,11 @@ class TestGPTTool(TestCase):
         tool.execute(cmd)
 
         gpt_cmd = 'gpt {} -f GeoTIFF-BigTIFF -t {} -param=val {}'.format(
-            os.path.join(os.getcwd(), 'gpt_graph.xml'),
+            os.path.join(os.getcwd(), graph_file_name),
             os.path.join(os.getcwd(), 'output'), os.path.join(os.getcwd(), 'input')).split()
         self.assertEqual(call_shell_command_mock.args, gpt_cmd)
         os.remove('input')
-        os.remove('gpt_graph.xml')
+        os.remove(graph_file_name)
 
     def test_missing_operation_and_graph(self):
         manifest = self.manifest.copy()

--- a/src/coresyftools/coresyftools/tests/test_tool.py
+++ b/src/coresyftools/coresyftools/tests/test_tool.py
@@ -298,8 +298,9 @@ class TestCoReSyFTool(TestCase):
         })
         with self.assertRaises(MissingCommandPlaceholderForOption):
             CoReSyFTool(self.runfile)
-        
+
     def test_can_use_custom_manifest_name(self):
+        """Test we can pass the manifest file name to CoReSyTFTool."""
         manifest = self.manifest.copy()
         manifest['name'] = 'MyFairTool'
         manifest_file_name = 'my_tool.manifest.json'
@@ -310,4 +311,4 @@ class TestCoReSyFTool(TestCase):
                          str(Path(self.runfile).parent / manifest_file_name))
         self.assertEqual(tool.manifest['name'], 'MyFairTool')
         os.remove(manifest_file_name)
-        
+

--- a/src/coresyftools/coresyftools/tests/test_tool.py
+++ b/src/coresyftools/coresyftools/tests/test_tool.py
@@ -2,6 +2,7 @@ import json
 import os
 from unittest import TestCase
 from zipfile import ZipFile
+from pathlib import Path
 
 from ..tool import (CoReSyFTool, EmptyOutputFile,
                     MissingCommandPlaceholderForOption, NoOutputFile,
@@ -297,3 +298,16 @@ class TestCoReSyFTool(TestCase):
         })
         with self.assertRaises(MissingCommandPlaceholderForOption):
             CoReSyFTool(self.runfile)
+        
+    def test_can_use_custom_manifest_name(self):
+        manifest = self.manifest.copy()
+        manifest['name'] = 'MyFairTool'
+        manifest_file_name = 'my_tool.manifest.json'
+        with open(manifest_file_name, 'w') as manifest_file:
+            manifest_file.write(json.dumps(manifest))
+        tool = CoReSyFTool(self.runfile, manifest_file_name)
+        self.assertEqual(tool.manifest_file_name,
+                         str(Path(self.runfile).parent / manifest_file_name))
+        self.assertEqual(tool.manifest['name'], 'MyFairTool')
+        os.remove(manifest_file_name)
+        

--- a/src/coresyftools/coresyftools/tests/tool4/manifest.json
+++ b/src/coresyftools/coresyftools/tests/tool4/manifest.json
@@ -21,7 +21,7 @@
             "name": "error message option",
             "type": "string",
             "description": "option to pass a error message for stderr",
-            "default": "error"
+            "default": false
         },
         {
             "identifier": "noutput",
@@ -42,6 +42,6 @@
         "identifier": "output",
         "name": "output",
         "description": "Sets the output file name to <filepath>",
-        "type": "Raster"        
+        "type": "Raster"
     }]
 }

--- a/src/coresyftools/coresyftools/tool.py
+++ b/src/coresyftools/coresyftools/tool.py
@@ -43,15 +43,15 @@ class EmptyOutputFile(Exception):
         self.file = file
 
 
+MANIFEST_FILE_NAME = 'manifest.json'
+
 class CoReSyFTool(object):
 
-    MANIFEST_FILE_NAME = 'manifest.json'
-
-    def __init__(self, run_script_file_name):
+    def __init__(self, run_script_file_name, manifest_file_name=MANIFEST_FILE_NAME):
         self.context_directory = self._get_context_directory(
             run_script_file_name)
         self.manifest_file_name = os.path.join(
-            self.context_directory, self.MANIFEST_FILE_NAME)
+            self.context_directory, manifest_file_name)
         self.manifest = get_manifest(self.manifest_file_name)
         self.arg_parser = CoReSyFArgumentParser(self.manifest)
         if 'command' in self.manifest:


### PR DESCRIPTION
- fix tests
- accepts manifest file name as `CoReSyFTool` argument
- accepts custom gpt graph file name in manifest from `operation.graph` field