### PR TITLE
Task/771 tif extension

### DIFF
--- a/src/coresyftools/coresyftools/gpt_tool.py
+++ b/src/coresyftools/coresyftools/gpt_tool.py
@@ -128,12 +128,12 @@ class GPTCoReSyFTool(CoReSyFTool):
             os.rename(gpt_file_name, target)
 
     def _add_tif_file_extension(self, source):
-        if os.path.exists(source) and self._has_no_extension(source):
+        if os.path.exists(source) and self._has_no_tif_extension(source):
             source_with_ext = source + '.' + self.TIF_EXT
             os.rename(source, source_with_ext)
             return source_with_ext
         else:
             return source
 
-    def _has_no_extension(self, file_name):
-        return os.path.splitext(str(file_name))[-1] == ''
+    def _has_no_tif_extension(self, file_name):
+        return os.path.splitext(str(file_name))[-1] != '.tif'

--- a/src/coresyftools/coresyftools/gpt_tool.py
+++ b/src/coresyftools/coresyftools/gpt_tool.py
@@ -59,7 +59,7 @@ class GPTCoReSyFTool(CoReSyFTool):
             graph_file = self._graph_file_path(operation)
             if not os.path.exists(graph_file):
                 raise GPTGraphFileNotFound(graph_file)
-    
+
     def run(self, bindings):
         if len(self.arg_parser.inputs) > 1:
             raise TooManyInputArgumentsException()
@@ -76,7 +76,10 @@ class GPTCoReSyFTool(CoReSyFTool):
         if 'parameters' in self.operation:
             bindings.update(self.operation['parameters'])
         source = bindings.pop(self.arg_parser.inputs[0])
-        source_with_ext = self._add_tif_file_extension(source) if self._has_geotiff_source() else source
+        if self._has_geotiff_source(): 
+            source_with_ext = self._add_tif_file_extension(source) 
+        else:
+            source_with_ext = source
         target = bindings.pop(self.arg_parser.outputs[0])
         self._call_gpt(operator, source_with_ext, target, bindings)
         # Remove source file extension (case it was added)
@@ -88,10 +91,10 @@ class GPTCoReSyFTool(CoReSyFTool):
         self._remove_tif_file_extension(target)
 
     def _has_geotiff_source(self):
-        return self._get_source_type() == self.GEOTIFF_TYPE 
-    
+        return self._get_source_type() == self.GEOTIFF_TYPE
+
     def _get_source_type(self):
-         return self.manifest['inputs'][0]['type']
+        return self.manifest['inputs'][0]['type']
 
     def _build_gpt_shell_command(self, operator, source, target, options):
         source = os.path.abspath(source)
@@ -136,4 +139,4 @@ class GPTCoReSyFTool(CoReSyFTool):
             return source
 
     def _has_no_tif_extension(self, file_name):
-        return os.path.splitext(str(file_name))[-1] != '.tif'
+        return os.path.splitext(str(file_name))[-1] !=  '.' + self.TIF_EXT

--- a/src/coresyftools/coresyftools/gpt_tool.py
+++ b/src/coresyftools/coresyftools/gpt_tool.py
@@ -34,7 +34,7 @@ class GPTCoReSyFTool(CoReSyFTool):
     '''CoReSyF Tool consisting of a single SNAP gpt operation.'''
 
     DEFAULT_FORMAT = 'GeoTIFF-BigTIFF'
-    DEFAULT_EXT = 'tif'
+    TIF_EXT = 'tif'
     DEFAULT_GPT_GRAPH_FILE_NAME = 'gpt_graph.xml'
     GEOTIFF_TYPE = 'GeoTIFF'
 
@@ -76,16 +76,16 @@ class GPTCoReSyFTool(CoReSyFTool):
         if 'parameters' in self.operation:
             bindings.update(self.operation['parameters'])
         source = bindings.pop(self.arg_parser.inputs[0])
-        source_with_ext = self._add_snap_file_extension(source) if self._has_geotiff_source() else source
+        source_with_ext = self._add_tif_file_extension(source) if self._has_geotiff_source() else source
         target = bindings.pop(self.arg_parser.outputs[0])
         self._call_gpt(operator, source_with_ext, target, bindings)
         # Remove source file extension (case it was added)
         if self._has_geotiff_source():
-            self._remove_snap_file_extension(source)
+            self._remove_tif_file_extension(source)
         # This is needed because SNAP automatically adds file extensions, but
         # output files can not have a name different from the specified in
         # the command line.
-        self._remove_snap_file_extension(target)
+        self._remove_tif_file_extension(target)
 
     def _has_geotiff_source(self):
         return self._get_source_type() == self.GEOTIFF_TYPE 
@@ -122,14 +122,14 @@ class GPTCoReSyFTool(CoReSyFTool):
         if process.returncode:
             raise GPTExecutionException(process.returncode, stderr)
 
-    def _remove_snap_file_extension(self, target):
-        gpt_file_name = target + '.' + self.DEFAULT_EXT
+    def _remove_tif_file_extension(self, target):
+        gpt_file_name = target + '.' + self.TIF_EXT
         if os.path.exists(gpt_file_name):
             os.rename(gpt_file_name, target)
 
-    def _add_snap_file_extension(self, source):
+    def _add_tif_file_extension(self, source):
         if os.path.exists(source) and self._has_no_extension(source):
-            source_with_ext = source + '.' + self.DEFAULT_EXT
+            source_with_ext = source + '.' + self.TIF_EXT
             os.rename(source, source_with_ext)
             return source_with_ext
         else:

--- a/src/coresyftools/coresyftools/gpt_tool.py
+++ b/src/coresyftools/coresyftools/gpt_tool.py
@@ -36,6 +36,7 @@ class GPTCoReSyFTool(CoReSyFTool):
     DEFAULT_FORMAT = 'GeoTIFF-BigTIFF'
     DEFAULT_EXT = 'tif'
     DEFAULT_GPT_GRAPH_FILE_NAME = 'gpt_graph.xml'
+    GEOTIFF_TYPE = 'GeoTIFF'
 
     def _graph_file_path(self, operation_dict):
         graph_file_name = self.DEFAULT_GPT_GRAPH_FILE_NAME
@@ -58,7 +59,7 @@ class GPTCoReSyFTool(CoReSyFTool):
             graph_file = self._graph_file_path(operation)
             if not os.path.exists(graph_file):
                 raise GPTGraphFileNotFound(graph_file)
-
+    
     def run(self, bindings):
         if len(self.arg_parser.inputs) > 1:
             raise TooManyInputArgumentsException()
@@ -75,15 +76,22 @@ class GPTCoReSyFTool(CoReSyFTool):
         if 'parameters' in self.operation:
             bindings.update(self.operation['parameters'])
         source = bindings.pop(self.arg_parser.inputs[0])
-        source_with_ext = self._add_snap_file_extension(source)
+        source_with_ext = self._add_snap_file_extension(source) if self._has_geotiff_source() else source
         target = bindings.pop(self.arg_parser.outputs[0])
         self._call_gpt(operator, source_with_ext, target, bindings)
         # Remove source file extension (case it was added)
-        self._remove_snap_file_extension(source)
+        if self._has_geotiff_source():
+            self._remove_snap_file_extension(source)
         # This is needed because SNAP automatically adds file extensions, but
         # output files can not have a name different from the specified in
         # the command line.
         self._remove_snap_file_extension(target)
+
+    def _has_geotiff_source(self):
+        return self._get_source_type() == self.GEOTIFF_TYPE 
+    
+    def _get_source_type(self):
+         return self.manifest['inputs'][0]['type']
 
     def _build_gpt_shell_command(self, operator, source, target, options):
         source = os.path.abspath(source)

--- a/src/coresyftools/coresyftools/tests/test_gpt_tool.py
+++ b/src/coresyftools/coresyftools/tests/test_gpt_tool.py
@@ -5,7 +5,6 @@ import os
 from ..gpt_tool import GPTCoReSyFTool, GPTGraphFileNotFound
 from ..manifest import InvalidManifestException
 
-
 class TestGPTTool(TestCase):
 
     def setUp(self):
@@ -153,8 +152,8 @@ class TestGPTTool(TestCase):
         self.assertEqual(call_shell_command_mock.args, gpt_cmd)
         os.remove('input')
 
-
     def test_can_add_extension_to_geotiff(self):
+        """Test that the .tif extension is added to a GeoTIFF source file without extension."""
         manifest = self.manifest.copy()
         manifest['operation'] = {'operation': 'Land-Sea-Mask'}
         self.write_manifest(manifest)
@@ -183,6 +182,7 @@ class TestGPTTool(TestCase):
         os.remove('input.tif')
 
     def test_can_add_extension_to_geotiff_when_has_different_extension(self):
+        """Test that a .tif extensions is added to a GeoTIFF source file with a extension other than '.tif'"""
         manifest = self.manifest.copy()
         manifest['operation'] = {'operation': 'Land-Sea-Mask'}
         self.write_manifest(manifest)
@@ -211,6 +211,7 @@ class TestGPTTool(TestCase):
         os.remove('input.txt.tif')
 
     def test_do_not_add_extension_to_geotiff_when_has_geotiff_extension(self):
+        """Test that a GeoTIFF source file is not renamed if it already has an .tif extension."""
         manifest = self.manifest.copy()
         manifest['operation'] = {'operation': 'Land-Sea-Mask'}
         self.write_manifest(manifest)
@@ -238,8 +239,8 @@ class TestGPTTool(TestCase):
         self.assertTrue(os.path.exists('input.tif'))
         os.remove('input.tif')
 
-
     def test_do_not_add_extension_to_non_geotiff(self):
+        """Test that a source file which is not GeoTIFF is not renamed."""
         manifest = self.manifest.copy()
         manifest['operation'] = {'operation': 'Land-Sea-Mask'}
         manifest['inputs'] = [{
@@ -273,8 +274,8 @@ class TestGPTTool(TestCase):
         self.assertTrue(os.path.exists('input'))
         os.remove('input')
 
-
-    def test_can_remove_added_extension(self):
+    def test_geotiff_source_file_ends_with_original_name(self):
+        """Test that a GeoTIFF source file gets the original name after the processing finish."""
         manifest = self.manifest.copy()
         manifest['operation'] = {'operation': 'Land-Sea-Mask'}
         self.write_manifest(manifest)

--- a/src/coresyftools/coresyftools/tests/test_gpt_tool.py
+++ b/src/coresyftools/coresyftools/tests/test_gpt_tool.py
@@ -17,6 +17,7 @@ class TestGPTTool(TestCase):
                     'identifier': 'input',
                     'name': 'input',
                     'description': 'description',
+                    'type': 'GeoTIFF'
                 }],
             'outputs': [
                 {
@@ -150,4 +151,124 @@ class TestGPTTool(TestCase):
         gpt_cmd = 'gpt Land-Sea-Mask -f GeoTIFF-BigTIFF -t {} -opt=a -const=1 -param=val {}'.format(
             os.path.join(os.getcwd(), 'output'), os.path.join(os.getcwd(), 'input.tif')).split()
         self.assertEqual(call_shell_command_mock.args, gpt_cmd)
+        os.remove('input')
+
+
+    def test_can_add_extension_to_geotiff(self):
+        manifest = self.manifest.copy()
+        manifest['operation'] = {'operation': 'Land-Sea-Mask'}
+        self.write_manifest(manifest)
+        tool = GPTCoReSyFTool(self.runfile)
+
+        class CallShellCommandMock():
+            def __call__(self, args):
+                self.args = args
+
+        call_shell_command_mock = CallShellCommandMock()
+
+        tool._call_shell_command = call_shell_command_mock
+
+        tool._remove_snap_file_extension = lambda x: None
+
+        with open('input', 'w') as infile:
+            infile.write('input')
+
+        cmd = '--input input --output output --param val'.split()
+        tool.execute(cmd)
+
+        gpt_cmd = 'gpt Land-Sea-Mask -f GeoTIFF-BigTIFF -t {} -param=val {}'.format(
+            os.path.join(os.getcwd(), 'output'), os.path.join(os.getcwd(), 'input.tif')).split()
+        self.assertEqual(call_shell_command_mock.args, gpt_cmd)
+        self.assertTrue(os.path.exists('input.tif'))
+        os.remove('input.tif')
+
+    def test_do_not_add_extension_to_geotiff_when_has_geotiff_extension(self):
+        manifest = self.manifest.copy()
+        manifest['operation'] = {'operation': 'Land-Sea-Mask'}
+        self.write_manifest(manifest)
+        tool = GPTCoReSyFTool(self.runfile)
+
+        class CallShellCommandMock():
+            def __call__(self, args):
+                self.args = args
+
+        call_shell_command_mock = CallShellCommandMock()
+
+        tool._call_shell_command = call_shell_command_mock
+
+        tool._remove_snap_file_extension = lambda x: None
+
+        with open('input.tif', 'w') as infile:
+            infile.write('input')
+
+        cmd = '--input input.tif --output output --param val'.split()
+        tool.execute(cmd)
+
+        gpt_cmd = 'gpt Land-Sea-Mask -f GeoTIFF-BigTIFF -t {} -param=val {}'.format(
+            os.path.join(os.getcwd(), 'output'), os.path.join(os.getcwd(), 'input.tif')).split()
+        self.assertEqual(call_shell_command_mock.args, gpt_cmd)
+        self.assertTrue(os.path.exists('input.tif'))
+        os.remove('input.tif')
+
+
+    def test_do_not_add_extension_to_non_geotiff(self):
+        manifest = self.manifest.copy()
+        manifest['operation'] = {'operation': 'Land-Sea-Mask'}
+        manifest['inputs'] = [{
+                    'identifier': 'input',
+                    'name': 'input',
+                    'description': 'description',
+                    'type': 'Raster'
+                }]
+        self.write_manifest(manifest)
+        tool = GPTCoReSyFTool(self.runfile)
+
+        class CallShellCommandMock():
+            def __call__(self, args):
+                self.args = args
+
+        call_shell_command_mock = CallShellCommandMock()
+
+        tool._call_shell_command = call_shell_command_mock
+
+        tool._remove_snap_file_extension = lambda x: None
+
+        with open('input', 'w') as infile:
+            infile.write('input')
+
+        cmd = '--input input --output output --param val'.split()
+        tool.execute(cmd)
+
+        gpt_cmd = 'gpt Land-Sea-Mask -f GeoTIFF-BigTIFF -t {} -param=val {}'.format(
+            os.path.join(os.getcwd(), 'output'), os.path.join(os.getcwd(), 'input')).split()
+        self.assertEqual(call_shell_command_mock.args, gpt_cmd)
+        self.assertTrue(os.path.exists('input'))
+        os.remove('input')
+
+
+    def test_can_remove_added_extension(self):
+        manifest = self.manifest.copy()
+        manifest['operation'] = {'operation': 'Land-Sea-Mask'}
+        self.write_manifest(manifest)
+        tool = GPTCoReSyFTool(self.runfile)
+
+        class CallShellCommandMock():
+            def __call__(self, args):
+                self.args = args
+
+        call_shell_command_mock = CallShellCommandMock()
+
+        tool._call_shell_command = call_shell_command_mock
+
+        with open('input', 'w') as infile:
+            infile.write('input')
+
+        cmd = '--input input --output output --param val'.split()
+        tool.execute(cmd)
+
+        gpt_cmd = 'gpt Land-Sea-Mask -f GeoTIFF-BigTIFF -t {} -param=val {}'.format(
+            os.path.join(os.getcwd(), 'output'), os.path.join(os.getcwd(), 'input.tif')).split()
+        self.assertEqual(call_shell_command_mock.args, gpt_cmd)
+        self.assertFalse(os.path.exists('input.tif'))
+        self.assertTrue(os.path.exists('input'))
         os.remove('input')

--- a/src/coresyftools/coresyftools/tests/test_gpt_tool.py
+++ b/src/coresyftools/coresyftools/tests/test_gpt_tool.py
@@ -168,7 +168,7 @@ class TestGPTTool(TestCase):
 
         tool._call_shell_command = call_shell_command_mock
 
-        tool._remove_snap_file_extension = lambda x: None
+        tool._remove_tif_file_extension = lambda x: None
 
         with open('input', 'w') as infile:
             infile.write('input')
@@ -196,7 +196,7 @@ class TestGPTTool(TestCase):
 
         tool._call_shell_command = call_shell_command_mock
 
-        tool._remove_snap_file_extension = lambda x: None
+        tool._remove_tif_file_extension = lambda x: None
 
         with open('input.tif', 'w') as infile:
             infile.write('input')
@@ -231,7 +231,7 @@ class TestGPTTool(TestCase):
 
         tool._call_shell_command = call_shell_command_mock
 
-        tool._remove_snap_file_extension = lambda x: None
+        tool._remove_tif_file_extension = lambda x: None
 
         with open('input', 'w') as infile:
             infile.write('input')


### PR DESCRIPTION
Adds a `.tif` extension to source inputs (both to the file and to the gpt invocation command) defined as `GeoTIFF` in the manifest, when the file do not have `.tif` extension.