### PR TITLE
Task/779 improve tool tester logs

### DIFF
--- a/src/coresyftools/coresyftools/packager.py
+++ b/src/coresyftools/coresyftools/packager.py
@@ -110,9 +110,14 @@ class Packager():
 @click.option('--scihub_pass')
 def pack_tool(tool_dir, target_dir, scihub_user, scihub_pass):
     click.echo('Packaging {} to {}..'.format(tool_dir, target_dir))
-    packager = Packager(tool_dir, target_dir, (scihub_user, scihub_pass))
-    packager.pack_tool()
-    click.echo('Packaging finished.')
+    try:
+        packager = Packager(tool_dir, target_dir, (scihub_user, scihub_pass))
+        packager.pack_tool()
+    except ToolErrorsException as tool_errors:
+        for error in tool_errors.errors:
+            click.echo('Packaging error: {}'.format(error), err=True)
+    else:
+        click.echo('Packaging finished.')
 
 if __name__ == '__main__':
     pack_tool()

--- a/src/coresyftools/coresyftools/packager.py
+++ b/src/coresyftools/coresyftools/packager.py
@@ -28,8 +28,10 @@ class MissingManifestFileException(Exception):
 class MissingExamplesFileException(Exception):
     pass
 
+
 class MultipleManifestFileException(Exception):
     pass
+
 
 class ToolErrorsException(Exception):
 
@@ -59,7 +61,7 @@ class Packager():
             raise MultipleManifestFileException()
         if not exists(join(self.tool_dir, 'examples.sh')):
             raise MissingExamplesFileException()
-    
+
     def _read_manifest(self):
         manifest_file_name = find_manifest_files(self.tool_dir)[0]
         self.manifest = get_manifest(manifest_file_name)
@@ -118,6 +120,7 @@ def pack_tool(tool_dir, target_dir, scihub_user, scihub_pass):
             click.echo('Packaging error: {}'.format(error), err=True)
     else:
         click.echo('Packaging finished.')
+
 
 if __name__ == '__main__':
     pack_tool()

--- a/src/coresyftools/coresyftools/tool.py
+++ b/src/coresyftools/coresyftools/tool.py
@@ -212,5 +212,3 @@ class CoReSyFTool(object):
                 archive.write(os.path.join(output_path, file_), file_)
             archive.close()
             shutil.rmtree(output_path)
-
-

--- a/src/coresyftools/coresyftools/tool.py
+++ b/src/coresyftools/coresyftools/tool.py
@@ -94,6 +94,7 @@ class CoReSyFTool(object):
         self.logger = logging.getLogger(CoReSyFTool.__name__)
         self.logger.addHandler(logging.StreamHandler(sys.stdout))
         self.logger.setLevel(logging.DEBUG)
+        self.logger.propagate = False
 
     def _get_logger(self):
         logger = logging.getLogger(self.__class__.__name__)

--- a/src/coresyftools/coresyftools/tool_tester.py
+++ b/src/coresyftools/coresyftools/tool_tester.py
@@ -3,9 +3,6 @@ import os
 import logging
 import subprocess
 import requests
-import json
-import glob
-from urlparse import urlparse
 from os.path import exists, getsize
 from argument_parser import CoReSyFArgumentParser
 from manifest import get_manifest, find_manifest_files
@@ -13,10 +10,11 @@ from manifest import get_manifest, find_manifest_files
 DOWNLOAD_TIMEOUT = 30
 SCHIHUB_DOMAIN = 'https://scihub.copernicus.eu'
 
+
 class InvalidInputSource(Exception):
-    
     def __init__(self, source_url):
         self.source_url = source_url
+
 
 class InvalidCommandException(Exception):
     pass
@@ -54,6 +52,7 @@ class ToolExampleCommand(object):
 
     def __str__(self):
         return ' '.join(self.command)
+
 
 class ToolTester(object):
 
@@ -161,7 +160,7 @@ class ToolTester(object):
         self.log[command] = stdout
         if returncode:
             self.errors.append(NonZeroReturnCode(returncode,
-                                self._byte_to_str(stderror)))
+                               self._byte_to_str(stderror)))
         elif stderror:
             self.errors.append(NonEmptyStderr(stderror))
         else:
@@ -196,6 +195,7 @@ class ToolTester(object):
         with open(file_name, "a+") as input_file:
             for chunk in response.iter_content(chunk_size=1024):
                 input_file.write(chunk)
+
 
 class TestFailure(Exception):
     pass


### PR DESCRIPTION
Errors/exceptions raised by the packaging tool are now displayed correctly. To test this, reinstall coresyftools on your local machine by running, in the folder src/coresyftools, "python2.7 setup.py install."
Then run packager.py with any of the existing tools, both with correct and incorrect parameters. Verify that in the case of incorrect parameters, the corresponding errors are correctly displayed.